### PR TITLE
Reformatted exhaustion list into tabular data & added full stops

### DIFF
--- a/js/data_condition.js
+++ b/js/data_condition.js
@@ -5,9 +5,9 @@ data_condition = [
         subtitle: "You can't see",
         description: "You can't see",
         bullets: [
-            "You automatically fail any ability check which requires sight",
-            "You have disadvantage on attack rolls",
-            "Attack rolls against you have advantage"
+            "You automatically fail any ability check which requires sight.",
+            "You have disadvantage on attack rolls.",
+            "Attack rolls against you have advantage."
         ]
     },
     {
@@ -16,8 +16,8 @@ data_condition = [
         subtitle: "You are charmed",
         description: "You are charmed by another creature",
         bullets: [
-            "You can't attack your charmer or target them with harmful abilities or magical effects",
-            "Your charmer has advantage on ability checks to interact socially with you"
+            "You can't attack your charmer or target them with harmful abilities or magical effects.",
+            "Your charmer has advantage on ability checks to interact socially with you."
         ]
     },
     {
@@ -26,7 +26,7 @@ data_condition = [
         subtitle: "You can't hear",
         description: "You can't hear",
         bullets: [
-            "You automatically fail any ability check which requires hearing"
+            "You automatically fail any ability check which requires hearing."
         ]
     },
     {
@@ -35,9 +35,9 @@ data_condition = [
         subtitle: "You are exhausted",
         description: "Exhaustion is measured in six levels",
         bullets: [
-            "<ol><li>Disadvantage on ability checks</li><li>Speed halved</li><li>Disadvantage on attack rolls and saving throws</li><li>Hit point maximum halved</li><li>Speed reduced to 0</li><li>Dead</li></ol>",
-            "You suffer the effect of your current level of exhaustion as well as all lower levels",
-            "Finishing a long rest reduces your exhaustion level by 1, provided that you have also had some food and drink"
+            "<table><tr><th>Level</th><th>Effect</th></tr><tr><td>1</td><td>Disadvantage on ability checks</td></tr><tr><td>2</td><td>Speed halved</td></tr><tr><td>3</td><td>Disadvantage on attack rolls and saving throws</td></tr><tr><td>4</td><td>Hit point maximum halved</td></tr><tr><td>5</td><td>Speed reduced to 0</td></tr><tr><td>6</td><td>Death</td></tr></table>",
+            "You suffer the effect of your current level of exhaustion as well as all lower levels.",
+            "Finishing a long rest reduces your exhaustion level by 1, provided that you have also had some food and drink."
         ]
     },
     {
@@ -46,8 +46,8 @@ data_condition = [
         subtitle: "You are frightened",
         description: "You are frightened",
         bullets: [
-            "You have disadvantage on ability checks and attack rolls while the source of your fear is within line of sight",
-            "You can't willingly move closer to the source of your fear"
+            "You have disadvantage on ability checks and attack rolls while the source of your fear is within line of sight.",
+            "You can't willingly move closer to the source of your fear."
         ]
     },
     {
@@ -56,9 +56,9 @@ data_condition = [
         subtitle: "You are grappled",
         description: "You are grappled",
         bullets: [
-            "Your speed becomes 0, and you can't benefit from any bonus to your speed",
-            "The condition ends if your grappler is incapacitated",
-            "The condition also ends if you are removed from the reach of your grappler"
+            "Your speed becomes 0, and you can't benefit from any bonus to your speed.",
+            "The condition ends if your grappler is incapacitated.",
+            "The condition also ends if you are removed from the reach of your grappler."
         ]
     },
     {
@@ -75,10 +75,10 @@ data_condition = [
         subtitle: "You can't be seen",
         description: "You can't be seen without the aid of magic or a special sense",
         bullets: [
-            "For the purpose of hiding, you are heavily obscured",
-            "You can still be detected by any noise you make or tracks you leave",
-            "You have advantage on attack rolls",
-            "Attack rolls against you have disadvantage"
+            "For the purpose of hiding, you are heavily obscured.",
+            "You can still be detected by any noise you make or tracks you leave.",
+            "You have advantage on attack rolls.",
+            "Attack rolls against you have disadvantage."
         ]
     },
     {
@@ -87,10 +87,10 @@ data_condition = [
         subtitle: "You are paralyzed",
         description: "You can't do anything",
         bullets: [
-            "You are incapacitated and can't move or speak",
-            "Attack rolls against you have advantage",
-            "Any attack that hits you is a critical hit if the attacker is within 5 feet of you",
-            "You automatically fail Strength and Dexterity saving throws"
+            "You are incapacitated and can't move or speak.",
+            "Attack rolls against you have advantage.",
+            "Any attack that hits you is a critical hit if the attacker is within 5 feet of you.",
+            "You automatically fail Strength and Dexterity saving throws."
         ]
     },
     {
@@ -99,12 +99,12 @@ data_condition = [
         subtitle: "You are transformed into stone",
         description: "You are transformed, along with any nonmagical objects you are wearing or carrying, into a solid inanimate substance (usually stone)",
         bullets: [
-            "Your weight increases by a factor of ten, and you cease aging",
-            "You are incapacitated, can't move or speak, and are unaware of your surroundings",
-            "Attack rolls against you have advantage",
-            "You automatically fail Strength and Dexterity saving throws",
-            "You have resistance to all damage",
-            "You are immune to poison and disease, though a poison or disease already in your system is only suspended, not neutralized"
+            "Your weight increases by a factor of ten, and you cease aging.",
+            "You are incapacitated, can't move or speak, and are unaware of your surroundings.",
+            "Attack rolls against you have advantage.",
+            "You automatically fail Strength and Dexterity saving throws.",
+            "You have resistance to all damage.",
+            "You are immune to poison and disease, though a poison or disease already in your system is only suspended, not neutralized."
         ]
     },
     {
@@ -113,7 +113,7 @@ data_condition = [
         subtitle: "You are poisoned",
         description: "You are poisoned",
         bullets: [
-            "You have disadvantage on attack rolls and ability checks"
+            "You have disadvantage on attack rolls and ability checks."
         ]
     },
     {
@@ -122,9 +122,9 @@ data_condition = [
         subtitle: "You are prone",
         description: "You are prone",
         bullets: [
-            "Your only movement option is to crawl, unless you stand up",
-            "You have disadvantage on attack rolls",
-            "Attack rolls against you have advantage if the attacker is within 5 feet of you, otherwise the attack roll has disadvantage"
+            "Your only movement option is to crawl, unless you stand up.",
+            "You have disadvantage on attack rolls.",
+            "Attack rolls against you have advantage if the attacker is within 5 feet of you, otherwise the attack roll has disadvantage."
         ]
     },
     {
@@ -133,10 +133,10 @@ data_condition = [
         subtitle: "You are restrained",
         description: "You are restrained",
         bullets: [
-            "Your speed becomes 0, and you can't benefit from any bonus to your speed",
-            "You have disadvantage on attack rolls",
-            "Attack rolls against you have advantage",
-            "You have disadvantage on Dexterity saving throws"
+            "Your speed becomes 0, and you can't benefit from any bonus to your speed.",
+            "You have disadvantage on attack rolls.",
+            "Attack rolls against you have advantage.",
+            "You have disadvantage on Dexterity saving throws."
         ]
     },
     {
@@ -145,9 +145,9 @@ data_condition = [
         subtitle: "You are stunned",
         description: "You are stunned",
         bullets: [
-            "You are incapacitated, can't move, and can speak only falteringly",
-            "Attack rolls against you have advantage",
-            "You automatically fail Strength and Dexterity saving throws"
+            "You are incapacitated, can't move, and can speak only falteringly.",
+            "Attack rolls against you have advantage.",
+            "You automatically fail Strength and Dexterity saving throws."
         ]
     },
     {
@@ -156,11 +156,11 @@ data_condition = [
         subtitle: "You are unconscious",
         description: "You are unconscious",
         bullets: [
-            "You are incapacitated, can't move or speak, and are unaware of your surroundings",
-            "You drop whatever you're holding and fall prone",
-            "Attack rolls against you have advantage",
-            "Any attack that hits you is a critical hit if the attacker is within 5 feet of you",
-            "You automatically fail Strength and Dexterity saving throws",
+            "You are incapacitated, can't move or speak, and are unaware of your surroundings.",
+            "You drop whatever you're holding and fall prone.",
+            "Attack rolls against you have advantage.",
+            "Any attack that hits you is a critical hit if the attacker is within 5 feet of you.",
+            "You automatically fail Strength and Dexterity saving throws.",
         ]
     }
 ]


### PR DESCRIPTION
To keep with the style that the original reference used, I've added full stops to the end of each line in the bullets sections of Conditions.
I also reformatted the data under "exhaustion" to be tabular, since it's more semantically correct, and also IMO looks a bit nicer. (Though would be nicer again with some CSS to make the first column a little wider and centre the numbering in the first line.)

EDIT: Oh, and I have no idea if I should have put this pull request here or in the original repository. Still kinda new to this whole thing…
